### PR TITLE
[DRAFT] Implement the `html()` example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # pep750-examples
 
-This repository contains the code examples found in [PEP 750: Template Strings](https://github.com/davepeck/peps/blob/pep750-post-sprint-update/peps/pep-0750.rst).
+This repository contains the code examples found in [PEP 750: Template Strings](https://peps.python.org/pep-0750/).
 
-## Running this code
+The repository includes a suite of tests to make sure the examples are correct.
 
-This repository contains a [devcontainer](https://containers.dev) definition that makes it easy to run the examples. The devcontainer includes a [fork of cpython 3.14](https://github.com/lysnikolaou/cpython/tree/tag-strings-rebased) that provides a prototype implementation of PEP 750.
+## Running This Code
 
-It's easy to use:
+This repo has a [devcontainer](https://containers.dev) definition that makes it easy to run the examples. The devcontainer includes a [fork of cpython 3.14](https://github.com/lysnikolaou/cpython/tree/tag-strings-rebased) that provides a prototype implementation of PEP 750.
+
+It's easy to run this code yourself:
 
 1. Make sure you have Docker installed
-2. Open this repository with `vscode`
+2. Clone this repository and open it with `vscode`
 3. When asked, say that you want to re-open _inside_ the devcontainer
 
 After the container is initialized, make sure that everything works by opening up a terminal in vscode. This will open in the running docker instance. Then:
@@ -17,36 +19,91 @@ After the container is initialized, make sure that everything works by opening u
 ```
 /workspaces/pep750-examples# python --version
 Python 3.14.0a0
+/workspaces/pep750-examples# pytest
+... (hopefully, all tests pass!) ...
 ```
 
 Congrats; you're good to go!
 
-The container includes `pytest` and a collection of tests to make sure the examples are correct.
 
+## A Word About the Code
+
+The current `cpython` implementation that this repository builds on top of tracks an _older_ version of PEP 750 with somewhat different syntax and semantics than the fully up-to-date PEP.
+
+Luckily, we can "smooth over" the important differences in a handful of lines of Python code. That's what's in the [`pep/__init__.py`](./pep/__init__.py) file.
+
+When PEP 750 lands in cpython, you'll be able to simply write a template string with a `t` prefix: `t"This is a template string"`. However, in this example code, because of the divergence between our `cpython` implementation and PEP 750, you first need to `from pep import t` in order to use the `t"Hello, World"` syntax.
+
+Likewise, when PEP 750 lands, you'll be able to `from types import Template, Interpolation`. Right now, those types are _also_ defined in the `pep` module.
+
+If you're just reading the example code and tests, you probably won't have to think about this. We'll update this repository when an updated version of `cpython` is available.
 
 ## Examples
 
-### f-string behavior
+### Implementing f-string Behavior
 
-The code in [`fstring.py`](./pep/fstring.py) implements f-string behavior on _top_ of t-strings, showcasing both how to work with the `Template` and `Interpolation` types, and making clear that t-strings are a generalization of f-strings.
+The code in [`fstring.py`](./pep/fstring.py) implements f-string behavior on _top_ of t-strings, showcasing both how to work with the `Template` and `Interpolation` types, and making clear that t-strings are a generalization of f-strings:
 
+```python
+name = "World"
+value = 42.0
+templated = t"Hello {name!r}, value: {value:.2f}"
+formatted = f"Hello {name!r}, value: {value:.2f}"
+assert f(templated) == formatted
+```
 See also [the tests](./pep/test_fstring.py).
 
-This example is described in detail in PEP 750.
+This [example is described in detail](https://peps.python.org/pep-0750/#example-implementing-f-strings-with-t-strings) in PEP 750.
 
-### Structured logging
+### Structured Logging
 
 The code in [`logging.py`](./pep/logging.py) implements two separate approaches to structured logging, showcasing how a single `logger.info(t"...")` call can lead to emitting both human-readable _and_ structured (in this case, JSON-formatted) data.
 
-The first approach follows the approach already found in the [Python Logging Cookbook](https://docs.python.org/3/howto/logging-cookbook.html#implementing-structured-logging); the second approach defines custom `Formatter`s that can be used to emit human-readable and structured output to different sinks (like two different files).
+The first approach follows the approach already found in the [Python Logging Cookbook](https://docs.python.org/3/howto/logging-cookbook.html#implementing-structured-logging); the second approach defines custom `Formatter`s that can be used to emit human-readable and structured output to different streams:
+
+```python
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+message_handler = logging.StreamHandler(sys.stdout)
+message_handler.setFormatter(MessageFormatter())
+logger.addHandler(handler)
+
+values_handler = logging.StreamHandler(sys.stderr)
+values_handler.setFormatter(ValuesFormatter())
+logger.addHandler(values_handler)
+
+action, amount, item = "traded", 42, "shrubs"
+logger.info(t"User {action}: {amount:.2f} {item}")
+
+# Outputs to sys.stdout:
+# User traded: 42.00 shrubs
+
+# At the same time, outputs to sys.stderr:
+# {"action": "traded", "amount": 42, "item": "shrubs"}
+```
 
 See the tests in [`test_logging.py`](./pep/test_logging.py).
 
-This example is described in detail in PEP 750.
+This [example is described in detail](https://peps.python.org/pep-0750/#example-structured-logging) in PEP 750.
 
-### html templating
+### HTML Templating
 
-IN PROGRESS
+There are several short "HTML templating" examples in [PEP 750](https://peps.python.org/pep-0750/).
 
-This example will be described in detail _here_ in this README, since it will _not_ be described in detail (only referenced) in PEP 750.
+They all use a hypothetical `html()` function that parses template strings to an intermediate type, `Element`, and supports context-dependent processing of interpolations.
+
+A real working implementation of `html()` is found in this repository's [`web.py`](./pep/web.py). Corresponding tests are found in [`test_web.py`](./pep/test_web.py).
+
+Building a full robust HTML templating package on top of template strings is both a noble goal _and_ beyond the scope of this example code. Instead, our goal is to hint at some interesting uses of template strings in the HTML context, and provide an early roadmap (warts and all) for how a more robust package could be built.
+
+The `html()` function parses `Template`s into an `Element` type:
+
+```python
+
+from dataclasses import dataclass
+
+@
+```
 

--- a/README.md
+++ b/README.md
@@ -96,14 +96,118 @@ They all use a hypothetical `html()` function that parses template strings to an
 
 A real working implementation of `html()` is found in this repository's [`web.py`](./pep/web.py). Corresponding tests are found in [`test_web.py`](./pep/test_web.py).
 
-Building a full robust HTML templating package on top of template strings is both a noble goal _and_ beyond the scope of this example code. Instead, our goal is to hint at some interesting uses of template strings in the HTML context, and provide an early roadmap (warts and all) for how a more robust package could be built.
+Building a full robust HTML templating package on top of template strings is both a noble goal _and_ beyond the scope of this example code. Instead, our goal is to hint at some interesting uses of template strings in the HTML context, and to provide an early roadmap (warts and all) for how a more robust package might be built.
 
-The `html()` function parses `Template`s into an `Element` type:
+The `Element` class is a simple representation of an HTML element:
 
 ```python
 
 from dataclasses import dataclass
 
-@
+@dataclass(frozen=True)
+class Element:
+    """A simple representation of an HTML element."""
+
+    tag: str  # An empty string indicates a fragment
+    attributes: Mapping[str, str | bool]
+    children: Sequence[Element | str]
+
+    def __str__(self) -> str:
+        ...
 ```
+
+Elements can be converted to strings:
+
+```python
+element = Element(tag="p", attributes={}, children=["hello"])
+assert str(element) == "<p>hello</p>"
+
+element2 = Element(tag="div", attributes={"id": "main"}, children=[element])
+assert str(element2) == '<div id="main"><p>hello</p></div>'
+```
+
+The `html()` function parses PEP 750 template strings to an `Element`:
+
+```python
+def html(template: Template) -> Element:
+    ...
+
+assert html(t"<p>hello</p>") == Element(tag="p", attributes={}, children=["hello"])
+```
+
+The `html()` function supports several features that decide how interpolations are processed based both on their type _and_ their position in the HTML syntax.
+
+Content can be interpolated into the body of an element:
+
+```python
+text = "Hello, World!"
+element = html(t"<p>{text}</p>")
+assert str(element) == "<p>Hello, World!</p>"
+```
+
+When content is interpolated, it is also automatically escaped:
+
+```python
+evil = "<script>alert('evil')</script>"
+element = html(t"<p>{evil}</p>")
+assert str(element) == "<p>&lt;script&gt;alert('evil')&lt;/script&gt;</p>"
+```
+
+Attribute values can be interpolated:
+
+```python
+src = "shrubbery.jpg"
+element = html(t'<img src={src} />')
+assert str(element) == '<img src="shrubbery.jpg" />'
+```
+
+Multiple attributes can be interpolated at once:
+
+```python
+attributes = {"src": "shrubbery.jpg", "alt": "A shrubbery"}
+element = html(t'<img {attributes} />')
+assert str(element) == '<img src="shrubbery.jpg" alt="A shrubbery" />'
+```
+
+Boolean attributes are also supported:
+
+```python
+attributes = {"type": "text", "required": True}
+element = html(t'<input {attributes} />')
+assert str(element) == '<input type="text" required />'
+```
+
+HTML `Element` instances can be nested:
+
+```python
+item1 = html(t"<li>Item 1</li>")
+item2 = html(t"<li>Item 2</li>")
+element = html(t"<ul>{item1}{item2}</ul>")
+assert str(element) == "<ul><li>Item 1</li><li>Item 2</li></ul>"
+```
+
+As a convenience, `html()` also supports a simplification for nesting: if an interpolation's value is a `Template`, it is automatically converted to an `Element`:
+
+```python
+item1 = t"<li>Item 1</li>"
+item2 = t"<li>Item 2</li>"
+element = html(t"<ul>{item1}{item2}</ul>")
+assert str(element) == "<ul><li>Item 1</li><li>Item 2</li></ul>"
+```
+
+**TODO**: The final interesting piece I intend to implement is a way to invoke a "component" function from within a template. In particular, the tag itself can be a function call:
+
+```python
+def magic(children: Sequence[Element | str], attributes: Mapping[str, str | bool]) -> Element:
+    """A simple, but extremely magical, component."""
+    magic_attributes = {**attributes, "data-magic": "yes"}
+    magic_children = [*children, "Magic!"]
+    return Element(tag="div", attributes=magic_attributes, children=magic_children)
+
+element = html(t"<{magic} id="wow"><b>FUN!</b></{magic}>")
+assert str(element) == '<div id="wow" data-magic="yes"><b>FUN!</b>Magic!</div>'
+```
+
+This isn't implemented... yet!
+
 

--- a/pep/__init__.py
+++ b/pep/__init__.py
@@ -20,6 +20,7 @@ spec and the new.
 """
 
 from dataclasses import dataclass
+from html.parser import HTMLParser
 from typing import Any
 from typing import Interpolation as OldVersionOfInterpolation
 from typing import Literal, Sequence
@@ -103,3 +104,33 @@ def t(*args: str | OldVersionOfInterpolation) -> Template:
     assert len(eo_args) % 2 == 1
 
     return Template(tuple(eo_args))
+
+
+#
+# Debug utilities -- useful when developing some of these examples
+#
+
+
+class _DebugParser(HTMLParser):
+    """
+    Parser that prints debug information about the HTML it's parsing.
+
+    Useful for learning how python's standard HTMLParser works.
+    """
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        print(f"starttag: {tag} {attrs}")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        print(f"startendtag: {tag} {attrs}")
+
+    def handle_endtag(self, tag: str) -> None:
+        print(f"endtag: {tag}")
+
+    def handle_data(self, data: str) -> None:
+        print(f"Data: {data}")
+
+    def parse_starttag(self, i: int) -> int:
+        response = super().parse_starttag(i)
+        print(f"parse_starttag: {i} -> {response}")
+        return response

--- a/pep/test_web.py
+++ b/pep/test_web.py
@@ -4,13 +4,13 @@ from deepdiff import DeepDiff
 from . import Template, t
 from .web import Element, HTMLParseError, html
 
-#
-# Tests for Element.__str__()
-#
+# ---------------------------------------------------------------------------
+# Tests for the Element class (mostly, its __str__ method)
+# ---------------------------------------------------------------------------
 
 
 def test_empty_element():
-    element = Element("", {}, [])
+    element = Element.empty()
     assert str(element) == ""
 
 
@@ -22,6 +22,31 @@ def test_empty_fragment():
 def test_fragment_with_text_children():
     element = Element.fragment(["Hello", "world"])
     assert str(element) == "Helloworld"
+
+
+def test_fragment_children_escape():
+    element = Element.fragment(["<script>alert('evil')</script>"])
+    assert str(element) == "&lt;script&gt;alert('evil')&lt;/script&gt;"
+
+
+def test_fragment_with_element_children():
+    element = Element.fragment(
+        [Element("p", {}, ["hello"]), Element("p", {}, ["world"])]
+    )
+    assert str(element) == "<p>hello</p><p>world</p>"
+
+
+def test_fragment_nesting():
+    fragment = Element.fragment(
+        [Element("p", {}, ["hello"]), Element("p", {}, ["world"])]
+    )
+    element = Element("div", {}, [Element("p", {}, ["wow"]), fragment])
+    assert str(element) == "<div><p>wow</p><p>hello</p><p>world</p></div>"
+
+
+def test_invalid_fragment():
+    with pytest.raises(ValueError):
+        _ = Element("", {"class": "greeting"}, [])
 
 
 def test_element_with_no_children():
@@ -57,9 +82,9 @@ def test_element_child_str_escape():
     assert str(element) == '<div>&lt;script&gt;alert("evil")&lt;/script&gt;</div>'
 
 
-#
-# Tests for html()
-#
+# ---------------------------------------------------------------------------
+# Tests for the html() template processing function
+# ---------------------------------------------------------------------------
 
 
 def test_html_empty():
@@ -102,8 +127,6 @@ def test_html_p_text_interpolation_escape():
     element = html(template)
     expected = Element("p", {}, ["<script>alert('evil')</script>"])
     assert element == expected
-    as_str = str(element)
-    assert as_str == "<p>&lt;script&gt;alert('evil')&lt;/script&gt;</p>"
 
 
 def test_html_nested_safe_text():
@@ -171,11 +194,11 @@ def test_html_many_nested_elements():
 
 
 def test_html_attribute_str_interploation():
-    cls = "greeting"
+    cls = 'gree"tin"g'
     text = "Hello, world!"
     template: Template = t"<p class={cls}>{text}</p>"
     element = html(template)
-    expected = Element("p", {"class": "greeting"}, ["Hello, world!"])
+    expected = Element("p", {"class": 'gree"tin"g'}, ["Hello, world!"])
     assert element == expected
 
 

--- a/pep/test_web.py
+++ b/pep/test_web.py
@@ -1,0 +1,141 @@
+import pytest
+from deepdiff import DeepDiff
+
+from . import Template, t
+from .web import Element, HTMLParseError, html
+
+#
+# Tests for Element.__str__()
+#
+
+
+def test_empty_element():
+    element = Element("", {}, [])
+    assert str(element) == ""
+
+
+def test_empty_fragment():
+    element = Element.fragment([])
+    assert str(element) == ""
+
+
+def test_fragment_with_text_children():
+    element = Element.fragment(["Hello", "world"])
+    assert str(element) == "Helloworld"
+
+
+def test_element_with_no_children():
+    element = Element("div", {}, [])
+    assert str(element) == "<div />"
+
+
+#
+# Tests for html()
+#
+
+
+def test_html_empty():
+    template: Template = t""
+    with pytest.raises(HTMLParseError):
+        element = html(template)
+
+
+def test_html_only_text():
+    template: Template = t"Hello, world!"
+    with pytest.raises(HTMLParseError):
+        element = html(template)
+
+
+def test_html_self_closing_tag():
+    template: Template = t"<br />"
+    element = html(template)
+    expected = Element("br", {}, [])
+    assert element == expected
+
+
+def test_html_simple_p():
+    template: Template = t"<p>Hello, world!</p>"
+    element = html(template)
+    expected = Element("p", {}, ["Hello, world!"])
+    assert element == expected
+
+
+def test_html_p_text_interpolation():
+    text = "Hello, world!"
+    template: Template = t"<p>{text}</p>"
+    element = html(template)
+    expected = Element("p", {}, ["Hello, world!"])
+    assert element == expected
+
+
+def test_html_p_with_attributes():
+    text = "Hello, world!"
+    template: Template = t'<p class="greeting">{text}</p>'
+    element = html(template)
+    expected = Element("p", {"class": "greeting"}, ["Hello, world!"])
+    assert element == expected
+
+
+def test_html_nested_elements():
+    template: Template = t"<div><p>Hello, world!</p></div>"
+    element = html(template)
+    expected = Element("div", {}, [Element("p", {}, ["Hello, world!"])])
+    assert element == expected
+
+
+def test_html_many_nested_elements():
+    template: Template = t"""
+    <div>
+        Raw text
+        <p>Hello, world!</p>
+        <ul>
+            <li>One</li>
+            <li>Two</li>
+            <li>Three</li>
+        </ul>
+    </div>
+    """
+    element = html(template)
+    expected = Element(
+        "div",
+        {},
+        [
+            "Raw text",
+            Element("p", {}, ["Hello, world!"]),
+            Element(
+                "ul",
+                {},
+                [
+                    Element("li", {}, ["One"]),
+                    Element("li", {}, ["Two"]),
+                    Element("li", {}, ["Three"]),
+                ],
+            ),
+        ],
+    )
+    diff = DeepDiff(element, expected)
+    assert not diff, f"Output differs:\n{diff}"
+
+
+def test_html_attribute_str_interploation():
+    cls = "greeting"
+    text = "Hello, world!"
+    template: Template = t"<p class={cls}>{text}</p>"
+    element = html(template)
+    expected = Element("p", {"class": "greeting"}, ["Hello, world!"])
+
+
+def test_html_attribute_dict_interpolation():
+    attributes = {"class": "greeting", "data-foo": True}
+    text = "Hello, world!"
+    template: Template = t"<p {attributes}>{text}</p>"
+    element = html(template)
+    expected = Element("p", {"class": "greeting", "data-foo": True}, ["Hello, world!"])
+    assert element == expected
+
+
+def test_html_dict_interpolation_not_allowed_in_content():
+    attributes = {"class": "greeting"}
+    template: Template = t"<p>{attributes}</p>"
+    with pytest.raises(HTMLParseError):
+        element = html(template)

--- a/pep/test_web.py
+++ b/pep/test_web.py
@@ -68,11 +68,34 @@ def test_html_p_text_interpolation():
     assert element == expected
 
 
+def test_html_p_text_interpolation_escape():
+    evil = "<script>alert('evil')</script>"
+    template: Template = t"<p>{evil}</p>"
+    element = html(template)
+    expected = Element("p", {}, ["&lt;script&gt;alert('evil')&lt;/script&gt;"])
+    assert element == expected
+
+
+def test_html_nested_safe_text():
+    good = html(t"<script>alert('good')</script>")
+    template: Template = t"<p>{good}</p>"
+    element = html(template)
+    expected = Element("p", {}, [Element("script", {}, ["alert('good')"])])
+    assert element == expected
+
+
+def test_html_nested_template_text():
+    good = t"<script>alert('good')</script>"
+    template: Template = t"<p>{good}</p>"
+    element = html(template)
+    expected = Element("p", {}, [Element("script", {}, ["alert('good')"])])
+
+
 def test_html_p_with_attributes():
-    text = "Hello, world!"
+    text = 'Hello, "world!"'
     template: Template = t'<p class="greeting">{text}</p>'
     element = html(template)
-    expected = Element("p", {"class": "greeting"}, ["Hello, world!"])
+    expected = Element("p", {"class": "greeting"}, ['Hello, "world!"'])
     assert element == expected
 
 

--- a/pep/test_web.py
+++ b/pep/test_web.py
@@ -72,8 +72,10 @@ def test_html_p_text_interpolation_escape():
     evil = "<script>alert('evil')</script>"
     template: Template = t"<p>{evil}</p>"
     element = html(template)
-    expected = Element("p", {}, ["&lt;script&gt;alert('evil')&lt;/script&gt;"])
+    expected = Element("p", {}, ["<script>alert('evil')</script>"])
     assert element == expected
+    as_str = str(element)
+    assert as_str == "<p>&lt;script&gt;alert('evil')&lt;/script&gt;</p>"
 
 
 def test_html_nested_safe_text():

--- a/pep/test_web.py
+++ b/pep/test_web.py
@@ -29,6 +29,34 @@ def test_element_with_no_children():
     assert str(element) == "<div />"
 
 
+def test_element_with_attributes():
+    element = Element("div", {"class": "greeting"}, [])
+    assert str(element) == '<div class="greeting" />'
+
+
+def test_element_with_text_children():
+    element = Element("div", {}, ["Hello", "world"])
+    assert str(element) == "<div>Helloworld</div>"
+
+
+def test_element_with_text_children_and_attributes():
+    element = Element("div", {"class": "greeting"}, ["Hello", "world"])
+    assert str(element) == '<div class="greeting">Helloworld</div>'
+
+
+def test_element_attribute_escape():
+    element = Element("div", {"class": 'greeting" onclick="alert("hi")'}, [])
+    assert (
+        str(element)
+        == '<div class="greeting&quot; onclick=&quot;alert(&quot;hi&quot;)" />'
+    )
+
+
+def test_element_child_str_escape():
+    element = Element("div", {}, ['<script>alert("evil")</script>'])
+    assert str(element) == '<div>&lt;script&gt;alert("evil")&lt;/script&gt;</div>'
+
+
 #
 # Tests for html()
 #
@@ -148,6 +176,7 @@ def test_html_attribute_str_interploation():
     template: Template = t"<p class={cls}>{text}</p>"
     element = html(template)
     expected = Element("p", {"class": "greeting"}, ["Hello, world!"])
+    assert element == expected
 
 
 def test_html_attribute_dict_interpolation():

--- a/pep/web.py
+++ b/pep/web.py
@@ -1,30 +1,46 @@
 from dataclasses import dataclass, field
 from html import escape
 from html.parser import HTMLParser
-from typing import Literal, Mapping, Sequence, cast
+from typing import Any, Literal, Mapping, Sequence, cast
 
 from . import Interpolation, Template
 
 
+class HTMLParseError(Exception):
+    """An error occurred while parsing an HTML template."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Utility code to render parts of an HTML element
+# ---------------------------------------------------------------------------
+
+
 def _render_str_attribute(key: str, value: str) -> str:
+    """Render a string attribute and its untrusted value."""
     return f'{key}="{escape(value, quote=True)}"'
 
 
 def _render_bool_attribute(key: str, value: bool) -> str:
+    """Render a boolean attribute if it's True."""
     return key if value else ""
 
 
 def _render_attribute(key: str, value: str | bool) -> str:
+    """Render an attribute and its value."""
     if isinstance(value, str):
         return _render_str_attribute(key, value)
     return _render_bool_attribute(key, value)
 
 
-def _render_attributes_dict(d: dict[str, str | bool]) -> str:
-    return " ".join(_render_attribute(key, value) for key, value in d.items())
+def _render_attributes_mapping(mapping: Mapping[str, str | bool]) -> str:
+    """Render a dictionary of attributes."""
+    return " ".join(_render_attribute(key, value) for key, value in mapping.items())
 
 
 def _render_children(children: Sequence[Element | str]) -> str:
+    """Render a sequence of children."""
     parts = []
     for child in children:
         if isinstance(child, Element):
@@ -35,13 +51,18 @@ def _render_children(children: Sequence[Element | str]) -> str:
     return "".join(parts)
 
 
+# ---------------------------------------------------------------------------
+# The main Element class
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class Element:
     """
     A simple representation of an HTML element.
 
     This makes no attempt to be a full-featured HTML representation or to
-    validate the input in any way. It's just a simple data structure that
+    validate the values in any way. It's just a simple data structure that
     can be rendered to a string.
     """
 
@@ -51,63 +72,56 @@ class Element:
 
     @classmethod
     def empty(cls) -> Element:
+        """Create an empty element."""
         return cls("", {}, [])
 
     @classmethod
     def fragment(cls, children: Sequence[Element | str]) -> Element:
+        """Create a fragment element (no tag)."""
         return cls("", {}, list(children))
 
-    @property
-    def is_fragment(self) -> bool:
-        return not self.tag
-
     def __post_init__(self):
-        if self.is_fragment and self.attributes:
+        if self.attributes and not self.tag:
             raise ValueError("Fragments cannot have attributes, only children")
 
     def __str__(self) -> str:
         # If there's no tag, render the children directly
         if not self.tag:
-            return "".join(str(child) for child in self.children)
+            return _render_children(self.children)
+
+        attributes_str = _render_attributes_mapping(self.attributes)
 
         # If there's no children, render the tag directly
-        attributes_str = _render_attributes_dict(self.attributes)
         if not self.children:
             if attributes_str:
                 return f"<{self.tag} {attributes_str} />"
             return f"<{self.tag} />"
 
         # Render the tag and children
+        # TODO handle indentation and pretty-printing
         children_str = _render_children(self.children)
         if attributes_str:
             return f"<{self.tag} {attributes_str}>{children_str}</{self.tag}>"
         return f"<{self.tag}>{children_str}</{self.tag}>"
 
 
-class HTMLParseError(Exception):
-    pass
-
-
-class _DebugParser(HTMLParser):
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
-        print(f"starttag: {tag} {attrs}")
-
-    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        print(f"startendtag: {tag} {attrs}")
-
-    def handle_endtag(self, tag: str) -> None:
-        print(f"endtag: {tag}")
-
-    def handle_data(self, data: str) -> None:
-        print(f"Data: {data}")
-
-    def parse_starttag(self, i: int) -> int:
-        response = super().parse_starttag(i)
-        print(f"parse_starttag: {i} -> {response}")
-        return response
+# ---------------------------------------------------------------------------
+# Our custom (but simple) HTML parser
+# ---------------------------------------------------------------------------
 
 
 class _Parser(HTMLParser):
+    """
+    A simple HTML parser that constructs an Element tree.
+
+    This builds on the standard library's HTMLParser. In a few places,
+    it effectively has to "hack" the standard library parser to get the desired
+    behavior.
+
+    For a production system, a more robust parser would likely be necessary:
+    writing robust template string processing code can be a lot of work!
+    """
+
     root: Element | None
     stack: list[Element]
     in_start_tag: bool
@@ -125,9 +139,10 @@ class _Parser(HTMLParser):
             )
 
         def _fix_none(value: str | None) -> str | bool:
-            if value is None:
-                return True
-            return value
+            """Convert None to True for boolean attributes."""
+            # Python's HTMLParser uses None to represent boolean attributes,
+            # but that's kinda weird. Let's convert it to True.
+            return True if value is None else value
 
         attributes = cast(
             dict[str, str | bool], {key: _fix_none(value) for key, value in attrs}
@@ -155,8 +170,60 @@ class _Parser(HTMLParser):
         self.stack[-1].children.append(data)
 
     def parse_starttag(self, i: int) -> int:
+        # A small hack to allow us to know when we're in a start tag
+        # (but not finish parsing it yet)
         self.in_start_tag = True
         return super().parse_starttag(i)
+
+
+# ---------------------------------------------------------------------------
+# Utility code to process HTML template interpolations
+# ---------------------------------------------------------------------------
+
+
+def _process_start_tag_interpolation(value: Any) -> str:
+    """
+    Process an interpolation value in a start tag.
+
+    Return the string representation of the value to feed to the parser.
+    """
+    if isinstance(value, Mapping):
+        # Render a collection of attributes in a mapping
+        return _render_attributes_mapping(value)
+    if isinstance(value, str):
+        # Escape a value to be used in an attribute
+        value = escape(value, quote=True)
+        # TODO We currently assume that we're inside an attribute value in
+        # the parse, but this may not always be the case.
+        return f'"{value}"'
+    raise HTMLParseError(
+        f"Unsupported start tag interpolation value type: {type(value)}"
+    )
+
+
+def _process_content_interpolation(value: Any) -> str:
+    """
+    Process an interpolation value outside of a start tag.
+
+    Return the string representation of the value to feed to the parser.
+    """
+    if isinstance(value, Element):
+        # Allow nesting elements in content
+        return str(value)
+    if isinstance(value, Template):
+        # Allow nesting templates in content by first processing them
+        # recursively with the html function
+        element = html(value)
+        return str(element)
+    if isinstance(value, str):
+        # Escape a value to be used in content
+        return escape(value, quote=False)
+    raise HTMLParseError(f"Unsupported content interpolation value type: {type(value)}")
+
+
+# ---------------------------------------------------------------------------
+# The main html() template processing function
+# ---------------------------------------------------------------------------
 
 
 def html(template: Template) -> Element:
@@ -165,31 +232,18 @@ def html(template: Template) -> Element:
     for arg in template.args:
         match arg:
             case str() as s:
+                # String content is easy: just continue to parse it as-is
                 parser.feed(s)
             case Interpolation() as i:
-                if isinstance(i.value, dict):
-                    if not parser.in_start_tag:
-                        raise HTMLParseError("Cannot interpolate dict in HTML content")
-                    parser.feed(_render_attributes_dict(i.value))
-                elif isinstance(i.value, Element):
-                    if parser.in_start_tag:
-                        raise HTMLParseError("Cannot interpolate Element in start tag")
-                    parser.feed(str(i.value))
-                elif isinstance(i.value, Template):
-                    if parser.in_start_tag:
-                        raise HTMLParseError("Cannot interpolate Template in start tag")
-                    result = html(i.value)
-                    parser.feed(str(result))
+                # Interpolations are more complex. They can be strings, dicts,
+                # Elements, or Templates. It matters *where* in the HTML grammar
+                # they appear, so we need to handle each case separately.
+                if parser.in_start_tag:
+                    value = _process_start_tag_interpolation(i.value)
                 else:
-                    value = i.value
-                    assert isinstance(value, str)
-                    if parser.in_start_tag:
-                        value = escape(value, quote=True)
-                        print(f"Escaped value in start tag: {value}")
-                    else:
-                        value = escape(value, quote=False)
-                        print(f"Escaped value NOT in start tag: {value}")
-                    parser.feed(value)
+                    # TODO what if we're in an end tag?
+                    value = _process_content_interpolation(i.value)
+                parser.feed(value)
     parser.close()
     if not parser.root:
         raise HTMLParseError("No root element")

--- a/pep/web.py
+++ b/pep/web.py
@@ -1,0 +1,181 @@
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Literal, Mapping, Sequence, cast
+
+from . import Interpolation, Template
+
+
+def _render_str_attribute(key: str, value: str) -> str:
+    return f'{key}="{value}"'
+
+
+def _render_bool_attribute(key: str, value: bool) -> str:
+    return key if value else ""
+
+
+def _render_attribute(key: str, value: str | bool) -> str:
+    if isinstance(value, str):
+        return _render_str_attribute(key, value)
+    return _render_bool_attribute(key, value)
+
+
+def _render_attributes_dict(d: dict[str, str | bool]) -> str:
+    return " ".join(_render_attribute(key, value) for key, value in d.items())
+
+
+@dataclass
+class Element:
+    """
+    A simple representation of an HTML element.
+
+    This makes no attempt to be a full-featured HTML representation or to
+    validate the input in any way. It's just a simple data structure that
+    can be rendered to a string.
+    """
+
+    tag: str  # An empty string represents a fragment
+    attributes: dict[str, str | bool]
+    children: list["Element | str"]
+
+    @classmethod
+    def empty(cls) -> Element:
+        return cls("", {}, [])
+
+    @classmethod
+    def fragment(cls, children: Sequence[Element | str]) -> Element:
+        return cls("", {}, list(children))
+
+    @property
+    def is_fragment(self) -> bool:
+        return not self.tag
+
+    def __post_init__(self):
+        if self.is_fragment and self.attributes:
+            raise ValueError("Fragments cannot have attributes, only children")
+
+    def _render_children(self) -> str:
+        parts = []
+        for child in self.children:
+            if isinstance(child, Element):
+                parts.append(str(child))
+            else:
+                parts.append(child)
+        return "".join(parts)
+
+    @property
+    def has_children(self) -> bool:
+        return bool(self.children)
+
+    def __str__(self) -> str:
+        # If there's no tag, render the children directly
+        if not self.tag:
+            return "".join(str(child) for child in self.children)
+
+        # If there's no children, render the tag directly
+        attributes_str = _render_attributes_dict(self.attributes)
+        if not self.has_children:
+            if attributes_str:
+                return f"<{self.tag} {attributes_str} />"
+            return f"<{self.tag} />"
+
+        # Render the tag and children
+        children_str = self._render_children()
+        if attributes_str:
+            return f"<{self.tag} {attributes_str}>\n{children_str}\n</{self.tag}>"
+        return f"<{self.tag}>\n{children_str}\n</{self.tag}>"
+
+
+class HTMLParseError(Exception):
+    pass
+
+
+class _DebugParser(HTMLParser):
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        print(f"starttag: {tag} {attrs}")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        print(f"startendtag: {tag} {attrs}")
+
+    def handle_endtag(self, tag: str) -> None:
+        print(f"endtag: {tag}")
+
+    def handle_data(self, data: str) -> None:
+        print(f"Data: {data}")
+
+    def parse_starttag(self, i: int) -> int:
+        response = super().parse_starttag(i)
+        print(f"parse_starttag: {i} -> {response}")
+        return response
+
+
+class _Parser(HTMLParser):
+    root: Element | None
+    stack: list[Element]
+    in_start_tag: bool
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stack = []
+        self.root = None
+        self.in_start_tag = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self.root is not None:
+            raise HTMLParseError(
+                f"Multiple root elements (starting with {self.root.tag} and finding {tag})"
+            )
+
+        def _fix_none(value: str | None) -> str | bool:
+            if value is None:
+                return True
+            return value
+
+        attributes = cast(
+            dict[str, str | bool], {key: _fix_none(value) for key, value in attrs}
+        )
+        element = Element(tag, attributes, [])
+        self.stack.append(element)
+        self.in_start_tag = False
+
+    def handle_endtag(self, tag: str) -> None:
+        element = self.stack.pop()
+        if element.tag != tag:
+            raise HTMLParseError(f"Unexpected end tag: {tag}")
+        if not self.stack:
+            self.root = element
+        else:
+            self.stack[-1].children.append(element)
+
+    def handle_data(self, data: str) -> None:
+        # Ignore whitespace (for now)
+        data = data.strip()
+        if not data:
+            return
+        if not self.stack:
+            raise HTMLParseError(f"Data outside of root element: {data}")
+        self.stack[-1].children.append(data.strip())
+
+    def parse_starttag(self, i: int) -> int:
+        self.in_start_tag = True
+        return super().parse_starttag(i)
+
+
+def html(template: Template) -> Element:
+    """Convert a Template to an Element."""
+    parser = _Parser()
+    for arg in template.args:
+        match arg:
+            case str() as s:
+                parser.feed(s)
+            case Interpolation() as i:
+                if isinstance(i.value, dict):
+                    if not parser.in_start_tag:
+                        raise HTMLParseError("Cannot interpolate dict in HTML content")
+                    parser.feed(_render_attributes_dict(i.value))
+                else:
+                    assert isinstance(i.value, str)
+                    parser.feed(i.value)
+    parser.close()
+    if not parser.root:
+        raise HTMLParseError("No root element")
+    return parser.root

--- a/pep/web.py
+++ b/pep/web.py
@@ -24,6 +24,17 @@ def _render_attributes_dict(d: dict[str, str | bool]) -> str:
     return " ".join(_render_attribute(key, value) for key, value in d.items())
 
 
+def _render_children(children: Sequence[Element | str]) -> str:
+    parts = []
+    for child in children:
+        if isinstance(child, Element):
+            parts.append(str(child))
+        else:
+            child = escape(child, quote=False)
+            parts.append(child)
+    return "".join(parts)
+
+
 @dataclass
 class Element:
     """
@@ -54,19 +65,6 @@ class Element:
         if self.is_fragment and self.attributes:
             raise ValueError("Fragments cannot have attributes, only children")
 
-    def _render_children(self) -> str:
-        parts = []
-        for child in self.children:
-            if isinstance(child, Element):
-                parts.append(str(child))
-            else:
-                parts.append(child)
-        return "".join(parts)
-
-    @property
-    def has_children(self) -> bool:
-        return bool(self.children)
-
     def __str__(self) -> str:
         # If there's no tag, render the children directly
         if not self.tag:
@@ -74,16 +72,16 @@ class Element:
 
         # If there's no children, render the tag directly
         attributes_str = _render_attributes_dict(self.attributes)
-        if not self.has_children:
+        if not self.children:
             if attributes_str:
                 return f"<{self.tag} {attributes_str} />"
             return f"<{self.tag} />"
 
         # Render the tag and children
-        children_str = self._render_children()
+        children_str = _render_children(self.children)
         if attributes_str:
-            return f"<{self.tag} {attributes_str}>\n{children_str}\n</{self.tag}>"
-        return f"<{self.tag}>\n{children_str}\n</{self.tag}>"
+            return f"<{self.tag} {attributes_str}>{children_str}</{self.tag}>"
+        return f"<{self.tag}>{children_str}</{self.tag}>"
 
 
 class HTMLParseError(Exception):
@@ -154,7 +152,6 @@ class _Parser(HTMLParser):
             return
         if not self.stack:
             raise HTMLParseError(f"Data outside of root element: {data}")
-        data = escape(data, quote=False)
         self.stack[-1].children.append(data)
 
     def parse_starttag(self, i: int) -> int:
@@ -180,7 +177,7 @@ def html(template: Template) -> Element:
                     parser.feed(str(i.value))
                 elif isinstance(i.value, Template):
                     if parser.in_start_tag:
-                        raise HTMLParseError("Cannot interpolate Element in start tag")
+                        raise HTMLParseError("Cannot interpolate Template in start tag")
                     result = html(i.value)
                     parser.feed(str(result))
                 else:

--- a/pep/web.py
+++ b/pep/web.py
@@ -7,7 +7,7 @@ from . import Interpolation, Template
 
 
 def _render_str_attribute(key: str, value: str) -> str:
-    return f'{key}="{value}"'
+    return f'{key}="{escape(value, quote=True)}"'
 
 
 def _render_bool_attribute(key: str, value: bool) -> str:

--- a/pep/web.py
+++ b/pep/web.py
@@ -56,19 +56,23 @@ def _render_children(children: Sequence[Element | str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class Element:
     """
     A simple representation of an HTML element.
 
-    This makes no attempt to be a full-featured HTML representation or to
-    validate the values in any way. It's just a simple data structure that
-    can be rendered to a string.
+    This makes no attempt to be a full-featured HTML representation, to be
+    performant, or to validate the presence of attributes or children in
+    any way. Instead, it's a simple data structure that can be rendered to
+    a string.
+
+    Hopefully it's a useful starting point for thinking about how to build
+    a more robust HTML templating system.
     """
 
-    tag: str  # An empty string represents a fragment
-    attributes: dict[str, str | bool]
-    children: list["Element | str"]
+    tag: str  # An empty string indicates a fragment
+    attributes: Mapping[str, str | bool]
+    children: Sequence["Element | str"]
 
     @classmethod
     def empty(cls) -> Element:
@@ -77,14 +81,20 @@ class Element:
 
     @classmethod
     def fragment(cls, children: Sequence[Element | str]) -> Element:
-        """Create a fragment element (no tag)."""
+        """Create a fragment element (empty tag)."""
         return cls("", {}, list(children))
 
     def __post_init__(self):
+        """Validate the element after it's been created."""
         if self.attributes and not self.tag:
             raise ValueError("Fragments cannot have attributes, only children")
 
+    def append(self, child: Element | str) -> Element:
+        """Append a child to the element."""
+        return Element(self.tag, self.attributes, list(self.children) + [child])
+
     def __str__(self) -> str:
+        """Render the element to an HTML string."""
         # If there's no tag, render the children directly
         if not self.tag:
             return _render_children(self.children)
@@ -112,14 +122,17 @@ class Element:
 
 class _Parser(HTMLParser):
     """
-    A simple HTML parser that constructs an Element tree.
+    A simple HTML parser that constructs a tree of `Element`s.
 
-    This builds on the standard library's HTMLParser. In a few places,
-    it effectively has to "hack" the standard library parser to get the desired
-    behavior.
+    This builds on the Python standard library's HTMLParser. This is fine for
+    our example purposes, but not perfect: we have to work around some of the
+    limitations of the parser (mostly, by overriding interal methods and
+    using internal state) in order to support our desired template string
+    syntax.
 
-    For a production system, a more robust parser would likely be necessary:
-    writing robust template string processing code can be a lot of work!
+    A production system would need a more robust parser, but that's potentially
+    a lot of work! Hopefully this is a useful starting point for thinking about
+    how to build a more robust HTML templating system.
     """
 
     root: Element | None
@@ -134,19 +147,15 @@ class _Parser(HTMLParser):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if self.root is not None:
-            raise HTMLParseError(
-                f"Multiple root elements (starting with {self.root.tag} and finding {tag})"
-            )
+            raise HTMLParseError(f"Multiple root elements ({self.root.tag} and {tag})")
 
-        def _fix_none(value: str | None) -> str | bool:
+        def _none_to_true(value: str | None) -> str | bool:
             """Convert None to True for boolean attributes."""
             # Python's HTMLParser uses None to represent boolean attributes,
             # but that's kinda weird. Let's convert it to True.
             return True if value is None else value
 
-        attributes = cast(
-            dict[str, str | bool], {key: _fix_none(value) for key, value in attrs}
-        )
+        attributes = {key: _none_to_true(value) for key, value in attrs}
         element = Element(tag, attributes, [])
         self.stack.append(element)
         self.in_start_tag = False
@@ -158,20 +167,22 @@ class _Parser(HTMLParser):
         if not self.stack:
             self.root = element
         else:
-            self.stack[-1].children.append(element)
+            self.stack[-1] = self.stack[-1].append(element)
 
     def handle_data(self, data: str) -> None:
-        # Ignore whitespace (for now)
+        # Ignore whitespace entirely for now
+        # TODO handle whitespace in a more sophisticated way
         data = data.strip()
         if not data:
             return
         if not self.stack:
             raise HTMLParseError(f"Data outside of root element: {data}")
-        self.stack[-1].children.append(data)
+        self.stack[-1] = self.stack[-1].append(data)
 
     def parse_starttag(self, i: int) -> int:
         # A small hack to allow us to know when we're in a start tag
-        # (but not finish parsing it yet)
+        # (but haven't finished parsing it yet)
+        # TODO: just how accurate is this? Is there a better way?
         self.in_start_tag = True
         return super().parse_starttag(i)
 
@@ -196,9 +207,7 @@ def _process_start_tag_interpolation(value: Any) -> str:
         # TODO We currently assume that we're inside an attribute value in
         # the parse, but this may not always be the case.
         return f'"{value}"'
-    raise HTMLParseError(
-        f"Unsupported start tag interpolation value type: {type(value)}"
-    )
+    raise HTMLParseError(f"Unsupported start tag interpolation: {type(value)}")
 
 
 def _process_content_interpolation(value: Any) -> str:
@@ -218,7 +227,9 @@ def _process_content_interpolation(value: Any) -> str:
     if isinstance(value, str):
         # Escape a value to be used in content
         return escape(value, quote=False)
-    raise HTMLParseError(f"Unsupported content interpolation value type: {type(value)}")
+    # TODO support "component" interpolations: callables that take
+    # the attributes and children and return an Element for rendering
+    raise HTMLParseError(f"Unsupported content interpolation: {type(value)}")
 
 
 # ---------------------------------------------------------------------------

--- a/pep/web.py
+++ b/pep/web.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from html import escape
 from html.parser import HTMLParser
 from typing import Literal, Mapping, Sequence, cast
 
@@ -153,7 +154,8 @@ class _Parser(HTMLParser):
             return
         if not self.stack:
             raise HTMLParseError(f"Data outside of root element: {data}")
-        self.stack[-1].children.append(data.strip())
+        data = escape(data, quote=False)
+        self.stack[-1].children.append(data)
 
     def parse_starttag(self, i: int) -> int:
         self.in_start_tag = True
@@ -172,9 +174,25 @@ def html(template: Template) -> Element:
                     if not parser.in_start_tag:
                         raise HTMLParseError("Cannot interpolate dict in HTML content")
                     parser.feed(_render_attributes_dict(i.value))
+                elif isinstance(i.value, Element):
+                    if parser.in_start_tag:
+                        raise HTMLParseError("Cannot interpolate Element in start tag")
+                    parser.feed(str(i.value))
+                elif isinstance(i.value, Template):
+                    if parser.in_start_tag:
+                        raise HTMLParseError("Cannot interpolate Element in start tag")
+                    result = html(i.value)
+                    parser.feed(str(result))
                 else:
-                    assert isinstance(i.value, str)
-                    parser.feed(i.value)
+                    value = i.value
+                    assert isinstance(value, str)
+                    if parser.in_start_tag:
+                        value = escape(value, quote=True)
+                        print(f"Escaped value in start tag: {value}")
+                    else:
+                        value = escape(value, quote=False)
+                        print(f"Escaped value NOT in start tag: {value}")
+                    parser.feed(value)
     parser.close()
     if not parser.root:
         raise HTMLParseError("No root element")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,3 +1,3 @@
 isort pep
 black pep
-pytest
+pytest $@


### PR DESCRIPTION
A very early work in progress.

What I've learned so far: working with Python's built in `html.parser.HTMLParser` is frustrating; there are a lot of bits of internal state that I effectively want access to (like "are we currently processing text in a context where attributes are expected, like an open tag or a self-closing tag") that I have to hack a bit to get answers to.

A real web templating implementation almost certainly needs to build its own parser, but I'll see how far I can go with `HTMLParser` for now.