### PR TITLE
Implement `Template.__add__()` and `Template.__radd__()`

### DIFF
--- a/pep/__init__.py
+++ b/pep/__init__.py
@@ -64,13 +64,10 @@ class Template:
         return Template(*self.args[:-1], self.args[-1] + other.args[0], *other.args[1:])
 
     def __radd__(self, other: object) -> Template:
-        assert isinstance(self.args[0], str)
-        if isinstance(other, str):
-            return Template(other + self.args[0], *self.args[1:])
-        if not isinstance(other, Template):
+        if not isinstance(other, str):
             return NotImplemented
-        assert isinstance(other.args[-1], str)
-        return Template(*other.args[:-1], other.args[-1] + self.args[0], *self.args[1:])
+        assert isinstance(self.args[0], str)
+        return Template(other + self.args[0], *self.args[1:])
 
 
 def t(*args: str | OldVersionOfInterpolation) -> Template:

--- a/pep/__init__.py
+++ b/pep/__init__.py
@@ -54,6 +54,24 @@ class Template:
     def __init__(self, *args: str | Interpolation):
         self.args = args
 
+    def __add__(self, other: object) -> Template:
+        assert isinstance(self.args[-1], str)
+        if isinstance(other, str):
+            return Template(*self.args[:-1], self.args[-1] + other)
+        if not isinstance(other, Template):
+            return NotImplemented
+        assert isinstance(other.args[0], str)
+        return Template(*self.args[:-1], self.args[-1] + other.args[0], *other.args[1:])
+
+    def __radd__(self, other: object) -> Template:
+        assert isinstance(self.args[0], str)
+        if isinstance(other, str):
+            return Template(other + self.args[0], *self.args[1:])
+        if not isinstance(other, Template):
+            return NotImplemented
+        assert isinstance(other.args[-1], str)
+        return Template(*other.args[:-1], other.args[-1] + self.args[0], *self.args[1:])
+
 
 def t(*args: str | OldVersionOfInterpolation) -> Template:
     """

--- a/pep/test.py
+++ b/pep/test.py
@@ -72,3 +72,88 @@ def test_format_spec_and_conv():
     assert template.args[1].value == 42
     assert template.args[1].conv == "r"
     assert template.args[1].format_spec == "04d"
+
+
+def test_add_template_str():
+    template = t"hello" + "world"
+    assert isinstance(template, Template)
+    assert len(template.args) == 1
+    assert isinstance(template.args[0], str)
+    assert template.args[0] == "hello" + "world"
+
+
+def test_add_template_str_2():
+    name = "world"
+    template = t"hello {name}!" + " how are you?"
+    assert isinstance(template, Template)
+    assert len(template.args) == 3
+    assert isinstance(template.args[0], str)
+    assert template.args[0] == "hello "
+    assert isinstance(template.args[1], Interpolation)
+    assert template.args[1].value == name
+    assert isinstance(template.args[2], str)
+    assert template.args[2] == "!" + " how are you?"
+
+
+def test_add_template_template():
+    template = t"hello" + t"world"
+    assert isinstance(template, Template)
+    assert len(template.args) == 1
+    assert isinstance(template.args[0], str)
+    assert template.args[0] == "hello" + "world"
+
+
+def test_add_template_template_2():
+    name = "world"
+    other = "you"
+    template = t"hello {name}!" + t" how are {other}?"
+    assert isinstance(template, Template)
+    assert len(template.args) == 5
+    assert isinstance(template.args[0], str)
+    assert template.args[0] == "hello "
+    assert isinstance(template.args[1], Interpolation)
+    assert template.args[1].value == name
+    assert isinstance(template.args[2], str)
+    assert template.args[2] == "!" + " how are "
+    assert isinstance(template.args[3], Interpolation)
+    assert template.args[3].value == other
+    assert isinstance(template.args[4], str)
+    assert template.args[4] == "?"
+
+
+def test_add_str_template():
+    template = "hello" + t"world"
+    assert isinstance(template, Template)
+    assert len(template.args) == 1
+    assert isinstance(template.args[0], str)
+    assert template.args[0] == "hello" + "world"
+
+
+def test_add_str_template_2():
+    name = "world"
+    template = "hello " + t"there, {name}!"
+    assert isinstance(template, Template)
+    assert len(template.args) == 3
+    assert isinstance(template.args[0], str)
+    assert template.args[0] == "hello " + "there, "
+    assert isinstance(template.args[1], Interpolation)
+    assert template.args[1].value == name
+    assert isinstance(template.args[2], str)
+    assert template.args[2] == "!"
+
+
+# This is not supported with the current branch of cpython
+# def test_implicit_concat_str_template():
+#     template = "hello" t"world"
+#     assert isinstance(template, Template)
+#     assert len(template.args) == 1
+#     assert isinstance(template.args[0], str)
+#     assert template.args[0] == "hello" + "world"
+
+# Nor is this
+# def test_implicit_concat_template_str():
+#     template = t"hello" "world"
+#     assert isinstance(template, Template)
+#     assert len(template.args) == 1
+#     assert isinstance(template.args[0], str)
+#     assert template.args[0] == "hello" + "world"


### PR DESCRIPTION
Here's an implementation that supports `Template + Template`, `str + Template`, and `Template + str` in roughly the way you'd expect.

Because we support interleaving, these are a tiny bit more complex than I would have hoped. _Without_ interleaving, you just append `args` and you're done. _With_ interleaving you have to manage the start and end strings differently.


