### PR TITLE
Add a plausible re-use example.

### DIFF
--- a/pep/reuse.py
+++ b/pep/reuse.py
@@ -1,0 +1,33 @@
+"""
+An example of how to build 'reusable' templates given the facilities
+provided by PEP 750.
+
+The question on the table is: how do we get to close to old-style `str.format`
+behavior, where we can build up a template and then apply it to multiple
+values?
+"""
+
+from . import Interpolation, Template
+from .fstring import convert
+
+
+class Formatter:
+    def __init__(self, template: Template):
+        for arg in template.args:
+            if isinstance(arg, Interpolation):
+                if not isinstance(arg.value, str):
+                    raise ValueError(f"Non-string interpolation: {arg.value}")
+        self.template = template
+
+    def format(self, **kwargs) -> str:
+        parts = []
+        for t_arg in self.template.args:
+            if isinstance(t_arg, str):
+                parts.append(t_arg)
+            else:
+                assert isinstance(t_arg.value, str)
+                value = kwargs[t_arg.value]
+                value = convert(value, t_arg.conv)
+                value = format(value, t_arg.format_spec)
+                parts.append(value)
+        return "".join(parts)

--- a/pep/test_reuse.py
+++ b/pep/test_reuse.py
@@ -6,4 +6,7 @@ def test_formatter():
     template: Template = t"This is a {'thing'} with value {'value':.2f}"
     formatter = Formatter(template)
     assert formatter.format(thing="pi", value=3.14159) == "This is a pi with value 3.14"
-    assert formatter.format(thing="e", value=2.71828) == "This is a e with value 2.72"
+    assert (
+        formatter.format(thing="cookie", value=42)
+        == "This is a cookie with value 42.00"
+    )

--- a/pep/test_reuse.py
+++ b/pep/test_reuse.py
@@ -1,0 +1,9 @@
+from . import Template, t
+from .reuse import Formatter
+
+
+def test_formatter():
+    template: Template = t"This is a {'thing'} with value {'value':.2f}"
+    formatter = Formatter(template)
+    assert formatter.format(thing="pi", value=3.14159) == "This is a pi with value 3.14"
+    assert formatter.format(thing="e", value=2.71828) == "This is a e with value 2.72"


### PR DESCRIPTION
We create a new class [`Formatter`](https://github.com/davepeck/pep750-examples/blob/d425325a4b11bd48b0edd51064b80890c1795536/pep/reuse.py#L14) that takes a template as input.

The only rule about the template is that its interpolation _values_ must be strings. These are later used as kwargs.

Then we can do the following:

```python
template = t"This is a {'thing'} with {'value':.02f}"
formatter = Formatter(template)
assert formatter.format(thing="pi", value=3.14159) = "This is a pi with value 3.14"
assert formatter.format(thing="cookie", value=42) = "This is a cookie with value 42.00"
```

I mean, I'd love it _more_ if I didn't have to wrap the values in quotes. But... y'know, maybe okay?

Likewise, also implement a `Binder` class. This late-binds values to a `Template`, generating a new `Template`:

```python
template = t"This is a {'thing'} with value {'value':.2f}"
binder = Binder(template)
bound = binder.bind(thing="pi", value=3.14159)
thing = "pi"
value = 3.14159
assert bound == t"This is a {thing} with value {value:.2f}"
```