### PR TITLE
Use string.Formatter to implement `from_format(...)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ as_template = from_format(old_style, 42, name="Alice")
 assert f(as_template) == "Thank you Alice for spending $42.00."
 ```
 
-The `from_format()` function supports essentially all the features of old-style format strings, including positional and keyword arguments, automatic and manual field numbering, format specifiers, and more.
+The `from_format()` function supports essentially all the features of old-style format strings, including positional and keyword arguments, automatic and manual field numbering, index and dot interpolation notation, nested format specifiers, and more.
 
 
 ### HTML Templating

--- a/pep/format.py
+++ b/pep/format.py
@@ -10,6 +10,43 @@ from typing import Literal
 from templatelib import Interpolation, Template
 
 
+def _split_field_name(field_name: str) -> tuple[str, str]:
+    """
+    Splits a field name into a key and a rest.
+
+    The key is the part before the first dot or open bracket. The rest is the
+    part after the first dot or open bracket.
+
+    If there is no dot or open bracket, the rest is an empty string.
+    """
+    # str.format() field names can be simple:
+    #
+    # 1. A number, which is a positional argument.
+    # 2. A name, which is a keyword argument.
+    # 3. Empty, which is an automatic field number.
+    #
+    # They can then tack on arbitrary indexing and attribute access:
+    #
+    # 1. .name accesses an attribute.
+    # 2. [name] accesses an item.
+    #
+    # We call the simple part the "key", and the indexing and attribute
+    # access the "rest".
+
+    first_dot = field_name.find(".")
+    first_open_brace = field_name.find("[")
+    if first_dot == -1 and first_open_brace == -1:
+        return field_name, ""
+    if first_dot == -1:
+        return field_name[:first_open_brace], field_name[first_open_brace:]
+    if first_open_brace == -1:
+        return field_name[:first_dot], field_name[first_dot:]
+    if first_dot < first_open_brace:
+        return field_name[:first_dot], field_name[first_dot:]
+    assert first_open_brace < first_dot
+    return field_name[:first_open_brace], field_name[first_open_brace:]
+
+
 def from_format(fmt: str, /, *args: object, **kwargs: object) -> Template:
     """
     Parses a format string intended for use with the `str.format()` method and
@@ -35,31 +72,39 @@ def from_format(fmt: str, /, *args: object, **kwargs: object) -> Template:
             if conversion not in {"s", "r", "a", None}:
                 raise ValueError(f"Unknown conversion specifier {conversion}")
 
-            if field_name.isdigit():
+            field_key, rest = _split_field_name(field_name)
+
+            # If field_key is a number, or is empty, support manual and automatic
+            # field numbering.
+            if field_key.isdigit():
                 if numbering_mode is None:
                     numbering_mode = "manual"
                 if numbering_mode != "manual":
                     raise ValueError(
                         "cannot switch from manual field specification to automatic field numbering"
                     )
-                key = field_name
-            elif not field_name:
+            elif not field_key:
                 if numbering_mode is None:
                     numbering_mode = "auto"
                 if numbering_mode != "auto":
                     raise ValueError(
                         "cannot switch from automatic field numbering to manual field specification"
                     )
-                key = str(auto_index)
+                field_key = str(auto_index)
                 auto_index += 1
-            else:
-                key = field_name
-            value, _ = formatter.get_field(key, args, kwargs)
+
+            # Recompose the field name with numbering mode taken into account
+            final_field = field_key + rest
+            value, _ = formatter.get_field(final_field, args, kwargs)
 
             # Handle nested interpolations in the format spec
             if format_spec and "{" in format_spec:
                 format_spec = format_spec.format(*args, **kwargs)
 
             # CONSIDER: what *is* the most reasonable `expr` to use here?
-            template_args.append(Interpolation(value, key, conversion, format_spec))
+            # for now, just use `final_field`, even though it is not
+            # necessarily a valid Python expression.
+            template_args.append(
+                Interpolation(value, final_field, conversion, format_spec)
+            )
     return Template(*template_args)

--- a/pep/format.py
+++ b/pep/format.py
@@ -9,112 +9,57 @@ from typing import Literal
 
 from templatelib import Interpolation, Template
 
-type ParsedIndex = int | None
-type ParsedKey = str | None
-type ParsedConversion = Literal["a", "r", "s"] | None
-type ParsedFormatSpec = str
-type ParsedInterpolation = tuple[
-    ParsedIndex, ParsedKey, ParsedFormatSpec, ParsedConversion
-]
-
-
-def _parse_fmt_string(fmt: str) -> tuple[str | ParsedInterpolation, ...]:
-    """
-    Parse a format string intended for use with `str.format()` and return a
-    list of static string parts and interpolation parts. These parts are
-    similar to, but not identical to, the parts of a `Template` instance;
-    the from_format() function below takes care of the final conversion.
-
-    This builds on top of string.Formatter.parse(), but has a slightly different
-    return structure.
-    """
-    formatter = string.Formatter()
-    parts: list[str | ParsedInterpolation] = []
-    mode: Literal["auto", "manual"] | None = None
-    auto_index = 0
-    for literal_text, field_name, format_spec, conversion in formatter.parse(fmt):
-        if literal_text:
-            parts.append(literal_text)
-        if field_name is not None:
-            if field_name.isdigit():
-                if mode is None:
-                    mode = "manual"
-                if mode != "manual":
-                    raise ValueError(
-                        "Cannot mix automatic field numbering with manual field numbering"
-                    )
-                index = int(field_name)
-                key = None
-            elif not field_name:
-                if mode is None:
-                    mode = "auto"
-                if mode != "auto":
-                    raise ValueError(
-                        "Cannot mix automatic field numbering with manual field numbering"
-                    )
-                index = auto_index
-                key = None
-                auto_index += 1
-            else:
-                index = None
-                key = field_name
-
-            if conversion not in {"s", "r", "a", None}:
-                raise ValueError(f"Invalid conversion specifier: {conversion}")
-            format_spec = format_spec or ""
-            if format_spec.startswith("{") and format_spec.endswith("}"):
-                raise NotImplementedError(
-                    "Expressions in format specifiers are not supported"
-                )
-            parts.append((index, key, format_spec, conversion))
-    return tuple(parts)
-
 
 def from_format(fmt: str, /, *args: object, **kwargs: object) -> Template:
     """
     Parses a format string intended for use with the `str.format()` method and
     returns an equivalent `Template` instance.
 
-    We support *nearly* all the grammatical features of the `str.format()` method,
-    including positional arguments with automatic or manual numbering, and
-    keyword arguments.
+    We support all the features of the `str.format()` method, including
+    positional arguments with automatic or manual numbering, keyword arguments,
+    interpolations with dot and indexing access, etc.
 
     We also support the limitations of `str.format()`, including lack of support
     for arbitrary expressions in interpolations (these are treated as keys) and
     lack of support for intermingling automatic field numbering with manual field
     numbering.
-
-    The one feature we don't *yet* support is the ability to use interpolations
-    inside format specifiers; currently, only literal format specifiers are
-    supported. As a result, this throws a NotImplementedError:
-
-        make_template("{:{}}", 42, ".2f")
-
-    There's no fundamental reason we couldn't support this, but it's a bit more
-    work, so we haven't done it yet.
     """
+    formatter = string.Formatter()
     template_args: list[str | Interpolation] = []
-    for part in _parse_fmt_string(fmt):
-        if isinstance(part, str):
-            template_args.append(part)
-        else:
-            index, key, format_spec, conversion_spec = part
-            if index is not None:
-                assert key is None
-                if index >= len(args):
-                    raise IndexError(
-                        f"Replacement index {index} out of range for positional args tuple"
+    numbering_mode: Literal["auto", "manual"] | None = None
+    auto_index = 0
+    for literal_text, field_name, format_spec, conversion in formatter.parse(fmt):
+        template_args.append(literal_text)
+        if field_name is not None:
+            format_spec = format_spec or ""
+            if conversion not in {"s", "r", "a", None}:
+                raise ValueError(f"Unknown conversion specifier {conversion}")
+
+            if field_name.isdigit():
+                if numbering_mode is None:
+                    numbering_mode = "manual"
+                if numbering_mode != "manual":
+                    raise ValueError(
+                        "cannot switch from manual field specification to automatic field numbering"
                     )
-                value = args[index]
-                expression = f"args[{index}]"
+                key = field_name
+            elif not field_name:
+                if numbering_mode is None:
+                    numbering_mode = "auto"
+                if numbering_mode != "auto":
+                    raise ValueError(
+                        "cannot switch from automatic field numbering to manual field specification"
+                    )
+                key = str(auto_index)
+                auto_index += 1
             else:
-                assert key is not None
-                if key not in kwargs:
-                    raise KeyError(key)
-                value = kwargs[key]
-                expression = f"kwargs[{key!r}]"
-            interpolation = Interpolation(
-                value, expression, conversion_spec, format_spec
-            )
-            template_args.append(interpolation)
+                key = field_name
+            value, _ = formatter.get_field(key, args, kwargs)
+
+            # Handle nested interpolations in the format spec
+            if format_spec and "{" in format_spec:
+                format_spec = format_spec.format(*args, **kwargs)
+
+            # CONSIDER: what *is* the most reasonable `expr` to use here?
+            template_args.append(Interpolation(value, key, conversion, format_spec))
     return Template(*template_args)

--- a/pep/format.py
+++ b/pep/format.py
@@ -4,6 +4,7 @@ Example code to take an old-school format string intended to be used with the
 """
 
 import re
+import string
 from typing import Literal
 
 from templatelib import Interpolation, Template
@@ -23,100 +24,50 @@ def _parse_fmt_string(fmt: str) -> tuple[str | ParsedInterpolation, ...]:
     list of static string parts and interpolation parts. These parts are
     similar to, but not identical to, the parts of a `Template` instance;
     the from_format() function below takes care of the final conversion.
+
+    This builds on top of string.Formatter.parse(), but has a slightly different
+    return structure.
     """
-    # Regular expression to match format specifiers, including conversion and format spec
-    # pattern = re.compile(r"(.*?)\{([^\{\}]*?)(?:!([sra]))?(?::([^\{\}]*?))?\}")
-    pattern = re.compile(
-        r"(.*?)\{([^\{\}]*?)(?:!([sra]))?(?::((?:[^\{\}]|\{[^\{\}]*\})*))?\}"
-    )
+    formatter = string.Formatter()
+    parts: list[str | ParsedInterpolation] = []
+    mode: Literal["auto", "manual"] | None = None
+    auto_index = 0
+    for literal_text, field_name, format_spec, conversion in formatter.parse(fmt):
+        if literal_text:
+            parts.append(literal_text)
+        if field_name is not None:
+            if field_name.isdigit():
+                if mode is None:
+                    mode = "manual"
+                if mode != "manual":
+                    raise ValueError(
+                        "Cannot mix automatic field numbering with manual field numbering"
+                    )
+                index = int(field_name)
+                key = None
+            elif not field_name:
+                if mode is None:
+                    mode = "auto"
+                if mode != "auto":
+                    raise ValueError(
+                        "Cannot mix automatic field numbering with manual field numbering"
+                    )
+                index = auto_index
+                key = None
+                auto_index += 1
+            else:
+                index = None
+                key = field_name
 
-    pos = 0
-    current_index = 0
-    numbering_mode: Literal["auto", "manual"] | None = None
-    result: list[str | ParsedInterpolation] = []
-
-    for match in pattern.finditer(fmt):
-        start, end = match.span()
-
-        # Add the preceding static string part, if any
-        if pos < start:
-            result.append(fmt[pos:start])
-
-        # Extract the parts
-        static_string = match.group(1)
-        key = match.group(2)
-        conversion_spec = match.group(3)
-        format_spec = match.group(4)
-
-        # Ensure the types are correct
-        assert isinstance(static_string, str)
-        assert isinstance(key, str)
-        assert isinstance(conversion_spec, str) or conversion_spec is None
-        assert isinstance(format_spec, str) or format_spec is None
-
-        if not conversion_spec:
-            conversion_spec = None
-
-        if conversion_spec not in {None, "a", "r", "s"}:
-            raise ValueError(f"Unknown conversion specifier: {conversion_spec}")
-
-        if format_spec is None:
-            format_spec = ""
-
-        # TODO we can definitely implement this in the future. But for now: why?
-        if format_spec and format_spec.startswith("{") and format_spec.endswith("}"):
-            raise NotImplementedError("Format spec interpolations are not supported")
-
-        # The regex will not match invalid conversion specifiers; they will
-        # end up in the key part. So we need to check for them here.
-        if "!" in key:
-            maybe_spec = key.split("!", maxsplit=1)[-1]
-            raise ValueError(f"Unknown conversion specifier: {maybe_spec}")
-
-        # Add the static string part from the match
-        if static_string:
-            result.append(static_string)
-
-        # Decide what kind of key this is. There are three possibilities:
-        #
-        # 1. An implicit index, e.g. "{}"
-        # 2. An explicit index, e.g. "{3}"
-        # 3. A key, e.g. "{name}" or "{0 + 1}"
-
-        if not key:
-            # This is an implicit index. Make sure we're in auto-numbering mode
-            # *or* move us *to* auto-numbering mode if we're not in manual mode.
-            if numbering_mode == "manual":
-                raise ValueError(
-                    "cannot switch from automatic field numbering to manual field specification"
+            if conversion not in {"s", "r", "a", None}:
+                raise ValueError(f"Invalid conversion specifier: {conversion}")
+            format_spec = format_spec or ""
+            if format_spec.startswith("{") and format_spec.endswith("}"):
+                raise NotImplementedError(
+                    "Expressions in format specifiers are not supported"
                 )
-            numbering_mode = "auto"
-            index = current_index
-            current_index += 1
-            key = None
-        elif key.isdigit():
-            # This is an explicit index
-            if numbering_mode == "auto":
-                raise ValueError(
-                    "cannot switch from automatic field numbering to manual field specification"
-                )
-            numbering_mode = "manual"
-            index = int(key)
-            key = None
-        else:
-            # This is a key
-            index = None
-
-        # Append it.
-        result.append((index, key, format_spec, conversion_spec))
-
-        pos = end
-
-    # Add any remaining static string part
-    if pos < len(fmt):
-        result.append(fmt[pos:])
-
-    return tuple(result)
+            parts.append((index, key, format_spec, conversion))
+    return tuple(parts)
 
 
 def from_format(fmt: str, /, *args: object, **kwargs: object) -> Template:

--- a/pep/test_format.py
+++ b/pep/test_format.py
@@ -1,7 +1,55 @@
 import pytest
 from templatelib import Interpolation, Template
 
-from .format import from_format
+from .format import _split_field_name, from_format
+
+
+def test_split_field_name_simple():
+    key, rest = _split_field_name("name")
+    assert key == "name"
+    assert rest == ""
+
+
+def test_split_field_name_dot():
+    key, rest = _split_field_name("name.attr")
+    assert key == "name"
+    assert rest == ".attr"
+
+
+def test_split_field_name_bracket():
+    key, rest = _split_field_name("name[0]")
+    assert key == "name"
+    assert rest == "[0]"
+
+
+def test_split_field_name_dot_bracket():
+    key, rest = _split_field_name("name.attr[0]")
+    assert key == "name"
+    assert rest == ".attr[0]"
+
+
+def test_split_field_name_bracket_dot():
+    key, rest = _split_field_name("name[0].attr")
+    assert key == "name"
+    assert rest == "[0].attr"
+
+
+def test_split_field_name_bracket_bracket():
+    key, rest = _split_field_name("name[0][1]")
+    assert key == "name"
+    assert rest == "[0][1]"
+
+
+def test_split_field_name_empty_key_dot():
+    key, rest = _split_field_name(".attr")
+    assert key == ""
+    assert rest == ".attr"
+
+
+def test_split_field_name_empty_key_bracket():
+    key, rest = _split_field_name("[0]")
+    assert key == ""
+    assert rest == "[0]"
 
 
 def _interpolation_almost_eq(i1: Interpolation, i2: Interpolation) -> bool:
@@ -99,16 +147,9 @@ def test_from_format_complex_manual_index_interpolation():
     assert _almost_eq(made, expected)
 
 
-def test_from_format_array_index_interpolation():
+def test_from_format_key_array_index_interpolation():
     name = "world"
     made: Template = from_format("Hello, {a[1]}!", a=[99, name])
-    expected: Template = t"Hello, {name}!"
-    assert _almost_eq(made, expected)
-
-
-def test_from_format_dotted_key_interpolation():
-    name = "world"
-    made: Template = from_format("Hello, {a.b}!", a=type("Namespace", (), {"b": name}))
     expected: Template = t"Hello, {name}!"
     assert _almost_eq(made, expected)
 
@@ -116,6 +157,90 @@ def test_from_format_dotted_key_interpolation():
 def test_from_format_auto_array_index_interpolation():
     name = "world"
     made: Template = from_format("Hello, {[1]}!", [99, name])
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_manual_array_index_interpolation():
+    name = "world"
+    made: Template = from_format("Hello, {0[1]}!", [99, name])
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_key_dot_interpolation():
+    name = "world"
+    made: Template = from_format("Hello, {a.b}!", a=type("Namespace", (), {"b": name}))
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_auto_dot_interpolation():
+    name = "world"
+    made: Template = from_format("Hello, {.b}!", type("Namespace", (), {"b": name}))
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_manual_dot_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {1.b}!", "nope", type("Namespace", (), {"b": name})
+    )
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_key_dot_array_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {a.b[1]}!", a=type("Namespace", (), {"b": [99, name]})
+    )
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_auto_dot_array_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {.b[1]}!", type("Namespace", (), {"b": [99, name]})
+    )
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_manual_dot_array_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {1.b[1]}!", "nope", type("Namespace", (), {"b": [99, name]})
+    )
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_key_array_dot_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {a[1].b}!", a=[99, type("Namespace", (), {"b": name})]
+    )
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_auto_array_dot_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {[1].b}!", [99, type("Namespace", (), {"b": name})]
+    )
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_manual_array_dot_interpolation():
+    name = "world"
+    made: Template = from_format(
+        "Hello, {0[1].b}!", [99, type("Namespace", (), {"b": name})]
+    )
     expected: Template = t"Hello, {name}!"
     assert _almost_eq(made, expected)
 

--- a/pep/test_format.py
+++ b/pep/test_format.py
@@ -99,6 +99,27 @@ def test_from_format_complex_manual_index_interpolation():
     assert _almost_eq(made, expected)
 
 
+def test_from_format_array_index_interpolation():
+    name = "world"
+    made: Template = from_format("Hello, {a[1]}!", a=[99, name])
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_dotted_key_interpolation():
+    name = "world"
+    made: Template = from_format("Hello, {a.b}!", a=type("Namespace", (), {"b": name}))
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_auto_array_index_interpolation():
+    name = "world"
+    made: Template = from_format("Hello, {[1]}!", [99, name])
+    expected: Template = t"Hello, {name}!"
+    assert _almost_eq(made, expected)
+
+
 def test_from_format_multiple_auto_index_interpolations():
     made: Template = from_format("{}{}", 99, "world")
     expected: Template = t"{99}{'world'}"

--- a/pep/test_format.py
+++ b/pep/test_format.py
@@ -1,139 +1,7 @@
 import pytest
 from templatelib import Interpolation, Template
 
-from .format import _parse_fmt_string, from_format
-
-#
-# Test the _parse_fmt_string(...) helper function
-#
-
-
-def test_parse_fmt_string_empty():
-    assert _parse_fmt_string("") == ()
-
-
-def test_parse_fmt_string_simple():
-    assert _parse_fmt_string("Hello!") == ("Hello!",)
-
-
-def test_parse_fmt_string_simple_key_interpolation():
-    assert _parse_fmt_string("{name}") == ((None, "name", "", None),)
-
-
-def test_parse_fmt_string_complex_key_interpolation():
-    assert _parse_fmt_string("{name!s:.2f}") == ((None, "name", ".2f", "s"),)
-
-
-def test_parse_fmt_string_simple_auto_index_interpolation():
-    assert _parse_fmt_string("{}") == ((0, None, "", None),)
-
-
-def test_parse_fmt_string_complex_auto_index_interpolation():
-    assert _parse_fmt_string("{!s:.2f}") == ((0, None, ".2f", "s"),)
-
-
-def test_parse_fmt_string_simple_manual_index_interpolation():
-    assert _parse_fmt_string("{1}") == ((1, None, "", None),)
-
-
-def test_parse_fmt_string_complex_manual_index_interpolation():
-    assert _parse_fmt_string("{1!s:.2f}") == ((1, None, ".2f", "s"),)
-
-
-def test_parse_fmt_string_multiple_auto_index_interpolations():
-    assert _parse_fmt_string("{}{}") == (
-        (0, None, "", None),
-        (1, None, "", None),
-    )
-
-
-def test_parse_fmt_string_multiple_manual_index_interpolations():
-    assert _parse_fmt_string("{1}{0}") == (
-        (1, None, "", None),
-        (0, None, "", None),
-    )
-
-
-def test_parse_fmt_string_interleaved_static_and_auto_index():
-    assert _parse_fmt_string("Hello, {}! What {}?") == (
-        "Hello, ",
-        (0, None, "", None),
-        "! What ",
-        (1, None, "", None),
-        "?",
-    )
-
-
-def test_parse_fmt_string_interleaved_static_and_manual_index():
-    assert _parse_fmt_string("Hello, {2}! What {17}?") == (
-        "Hello, ",
-        (2, None, "", None),
-        "! What ",
-        (17, None, "", None),
-        "?",
-    )
-
-
-def test_parse_fmt_string_invalid_auto_to_manual_index():
-    with pytest.raises(ValueError):
-        _ = _parse_fmt_string("{}{1}")
-
-
-def test_parse_fmt_string_invalid_manual_to_auto_index():
-    with pytest.raises(ValueError):
-        _ = _parse_fmt_string("{1}{}")
-
-
-def test_parse_fmt_string_invalid_conversion_spec():
-    with pytest.raises(ValueError):
-        _ = _parse_fmt_string("{name!z}")
-
-
-def test_parse_fmt_string_invalid_conversion_spec_too_many_chars():
-    with pytest.raises(ValueError):
-        result = _parse_fmt_string("{name!ss}")
-        print(result)
-
-
-def test_fmt_string_mixed_static_auto_and_key_interpolations():
-    assert _parse_fmt_string("Hello, {}{name}!") == (
-        "Hello, ",
-        (0, None, "", None),
-        (None, "name", "", None),
-        "!",
-    )
-
-
-def test_fmt_string_mixed_static_manual_and_key_interpolations():
-    assert _parse_fmt_string("Hello, {1}{name}!") == (
-        "Hello, ",
-        (1, None, "", None),
-        (None, "name", "", None),
-        "!",
-    )
-
-
-def test_parse_fmt_string_complex():
-    assert _parse_fmt_string("{}{wow}Hello, {}{name!s:.2f}!{:fun}") == (
-        (0, None, "", None),
-        (None, "wow", "", None),
-        "Hello, ",
-        (1, None, "", None),
-        (None, "name", ".2f", "s"),
-        "!",
-        (2, None, "fun", None),
-    )
-
-
-def test_parse_fmt_string_nested_interpolations():
-    with pytest.raises(NotImplementedError):
-        parsed = _parse_fmt_string("{name:{fmt}}")
-        print(parsed)
-
-
-#
-# Test the fancy from_format(...) function
-#
+from .format import from_format
 
 
 def _interpolation_almost_eq(i1: Interpolation, i2: Interpolation) -> bool:
@@ -299,6 +167,35 @@ def test_from_format_complex():
     assert _almost_eq(made, expected)
 
 
-def test_from_format_nested_interpolations():
-    with pytest.raises(NotImplementedError):
-        _ = from_format("{name:{fmt}}", name="world", fmt=".2f")
+def test_from_format_format_spec_with_full_interpolation():
+    number = 42
+    fmt = ".2f"
+    made: Template = from_format("{number:{fmt}}", number=number, fmt=fmt)
+    expected: Template = t"{number:{fmt}}"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_format_spec_with_part_interpolation():
+    number = 42
+    precision = 2
+    made: Template = from_format(
+        "{number:.{precision}f}", number=number, precision=precision
+    )
+    expected: Template = t"{number:.{precision}f}"
+    assert _almost_eq(made, expected)
+
+
+def test_from_format_format_spec_with_multiple_interpolations():
+    number = 42
+    dot = "."
+    precision = 2
+    kind = "f"
+    made: Template = from_format(
+        "{number:{dot}{precision}{kind}}",
+        number=number,
+        dot=dot,
+        precision=precision,
+        kind=kind,
+    )
+    expected: Template = t"{number:{dot}{precision}{kind}}"
+    assert _almost_eq(made, expected)


### PR DESCRIPTION
This simplifies and completes the `from_format()` implementation, adding support for:

- Nested interpolations in format specs (`"{number:.{precision}f}"`)
- Array index and dot notation, including with manual and automatic field numbering (`"{foo.bar}"`, `"{foo[7]}"`, `"{.bar}"`, `"{[7]}"`, `"{3.bar}"`, etc.) 

And more.