### PR TITLE
Rewrite our examples to use `pairs()` rather than walking over `template.args` directly.

### DIFF
--- a/pep/__init__.py
+++ b/pep/__init__.py
@@ -1,6 +1,9 @@
 """Examples for PEP 750. See README.md for details."""
 
+import typing as t
 from html.parser import HTMLParser
+
+from templatelib import Interpolation, Template
 
 #
 # Known bugs/divergences between cpython/tstrings and the current PEP 750 spec
@@ -86,3 +89,30 @@ class _DebugParser(HTMLParser):
         response = super().parse_starttag(i)
         print(f"parse_starttag: {i} -> {response}")
         return response
+
+
+class InterpolationProto(t.Protocol):
+    """
+    This exists only to get my type checking tools, which do not currently
+    know about templatelib, to understand the structure of an Interpolation
+    when surfaced by pairs(), below.
+    """
+
+    value: object
+    expr: str
+    conv: t.Literal["a", "r", "s"] | None
+    format_spec: str
+
+
+def pairs(template: Template) -> t.Iterator[tuple[InterpolationProto | None, str]]:
+    """
+    Yield pairs of interpolations and strings from a template.
+
+    This allows us to experiment with the structure of a template;
+    see the discussion here:
+
+    https://discuss.python.org/t/pep750-template-strings-new-updates/71594/65
+    """
+    yield None, template.args[0]
+    for i, s in zip(template.args[1::2], template.args[2::2]):
+        yield i, s

--- a/pep/__init__.py
+++ b/pep/__init__.py
@@ -116,3 +116,17 @@ def pairs(template: Template) -> t.Iterator[tuple[InterpolationProto | None, str
     yield None, template.args[0]
     for i, s in zip(template.args[1::2], template.args[2::2]):
         yield i, s
+
+
+def pairs_s_i(template: Template) -> t.Iterator[tuple[str, Interpolation | None]]:
+    """
+    Yield pairs of strings and interpolations from a template.
+
+    This allows us to experiment with the structure of a template;
+    it is the *opposite* of Guido's pairs() proposal as discussed here:
+
+    https://discuss.python.org/t/pep750-template-strings-new-updates/71594/65
+    """
+    for s, i in zip(template.args[::2], template.args[1::2]):
+        yield s, i
+    yield template.args[-1], None

--- a/pep/afstring.py
+++ b/pep/afstring.py
@@ -6,8 +6,9 @@ See also `test_afstring.py`
 
 import inspect
 
-from templatelib import Interpolation, Template
+from templatelib import Template
 
+from . import pairs
 from .fstring import convert
 
 
@@ -21,16 +22,14 @@ async def async_f(template: Template) -> str:
     formatting it.
     """
     parts = []
-    for arg in template.args:
-        match arg:
-            case str() as s:
-                parts.append(s)
-            case Interpolation(value, _, conv, format_spec):
-                if inspect.iscoroutinefunction(value):
-                    value = await value()
-                elif callable(value):
-                    value = value()
-                value = convert(value, conv)
-                value = format(value, format_spec)
-                parts.append(value)
+    for i, s in pairs(template):
+        if i is not None:
+            if inspect.iscoroutinefunction(i.value):
+                value = await i.value()
+            elif callable(i.value):
+                value = i.value()
+            value = convert(value, i.conv)
+            value = format(value, i.format_spec)
+            parts.append(value)
+        parts.append(s)
     return "".join(parts)

--- a/pep/lazy.py
+++ b/pep/lazy.py
@@ -2,6 +2,7 @@
 
 from templatelib import Template
 
+from . import pairs
 from .fstring import convert
 
 
@@ -18,16 +19,15 @@ def format_some(selector: str, template: Template, ignored: str = "***") -> str:
     unnecessary.
     """
     parts = []
-    for t_arg in template.args:
-        if isinstance(t_arg, str):
-            parts.append(t_arg)
-        else:
-            if t_arg.format_spec == selector:
-                value = t_arg.value
+    for i, s in pairs(template):
+        if i is not None:
+            if i.format_spec == selector:
+                value = i.value
                 if callable(value):
                     value = value()
-                value = convert(value, t_arg.conv)
+                value = convert(value, i.conv)
             else:
                 value = ignored
             parts.append(value)
+        parts.append(s)
     return "".join(parts)

--- a/pep/logging.py
+++ b/pep/logging.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, Mapping, Protocol
 
 from templatelib import Interpolation, Template
 
+from . import pairs
 from .fstring import f
 
 
@@ -35,11 +36,7 @@ class TemplateMessage:
 
     @property
     def values(self) -> Mapping[str, object]:
-        return {
-            arg.expr: arg.value
-            for arg in self.template.args
-            if isinstance(arg, Interpolation)
-        }
+        return {i.expr: i.value for i, _ in pairs(self.template) if i is not None}
 
     @property
     def data(self) -> Mapping[str, object]:
@@ -103,11 +100,7 @@ class ValuesFormatter(TemplateFormatterBase):
     """A formatter that formats structured output from a Template's values."""
 
     def values(self, template: Template) -> Mapping[str, object]:
-        return {
-            arg.expr: arg.value
-            for arg in template.args
-            if isinstance(arg, Interpolation)
-        }
+        return {i.expr: i.value for i, _ in pairs(template) if i is not None}
 
     def format(self, record: LogRecord) -> str:
         msg = record.msg


### PR DESCRIPTION
As described [in this discussion](https://discuss.python.org/t/pep750-template-strings-new-updates/71594/60).

 