### PR TITLE
Fix handler variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import sys
 logger = logging.getLogger(__name__)
 message_handler = logging.StreamHandler(sys.stdout)
 message_handler.setFormatter(MessageFormatter())
-logger.addHandler(handler)
+logger.addHandler(message_handler)
 
 values_handler = logging.StreamHandler(sys.stderr)
 values_handler.setFormatter(ValuesFormatter())


### PR DESCRIPTION
This PR corrects the usage of the `handler` variable in the README to `message_handler`, matching the rest of the example.

No functional code changes; documentation fix only.
